### PR TITLE
Adding missing `BACKEND_API_URL` env

### DIFF
--- a/Tech-Lab-On-Campus/NewsFeed/docker-compose.yml
+++ b/Tech-Lab-On-Campus/NewsFeed/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - BACKEND_API_URL=http://0.0.0.0:8000
     volumes:
       - .:/workspace
     command: /bin/bash


### PR DESCRIPTION
Sometimes the frontend and backend were not communicating because the frontend expects `BACKEND_API_URL` to be set but it is not currently set in the env.